### PR TITLE
Updated broken AMQPNetLite NuGet package reference

### DIFF
--- a/Devices/RaspberryPiGateway/RaspberryPIGateway.csproj
+++ b/Devices/RaspberryPiGateway/RaspberryPIGateway.csproj
@@ -32,14 +32,14 @@
     <DefineConstants>TRACE</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Amqp.Net">
+      <HintPath>..\..\packages\AMQPNetLite.0.1.0-beta\lib\net\Amqp.Net.dll</HintPath>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\Newtonsoft.Json.6.0.6\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="Amqp.Net">
-      <HintPath>..\..\packages\AMQPNetLite.0.1.0-alpha\lib\net\Amqp.Net.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Program.cs" />

--- a/Devices/RaspberryPiGateway/packages.config
+++ b/Devices/RaspberryPiGateway/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AMQPNetLite" version="0.1.0-alpha" targetFramework="net45" />
+  <package id="AMQPNetLite" version="0.1.0-beta" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.6" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Updated the NuGet package reference for AMQPNetLite. A prerelease package is now available publicly. The previous package was never published.

Note that the Step-By-Step wiki page needs to be updated if the pull request is accepted. It has instructions on building the NuGet package from the source.
