### PR TITLE
Add an another hack to solve the Azure Stream Analytics Preview output issue 

### DIFF
--- a/Azure/ConnectTheDotsWebSite/WebSocketEventProcessor.cs
+++ b/Azure/ConnectTheDotsWebSite/WebSocketEventProcessor.cs
@@ -88,6 +88,11 @@ namespace WebClient
                         
                         // Azure Stream Analytics Preview generates invalid JSON for some multi-values queries
                         // Workaround: turn concatenated json objects (ivalid JSON) into array of json objects (valid JSON)
+                        if (eventBodyAsString.IndexOf("[{") >= 0 && eventBodyAsString.IndexOf("}]") < 0)
+                        {
+                            eventBodyAsString = eventBodyAsString + "]";
+                        }
+
                         if (eventBodyAsString.IndexOf("}{") >= 0)
                         {
                             eventBodyAsString = eventBodyAsString.Replace("}{", "},{");


### PR DESCRIPTION
The last version of ASA Preview puts to output invalid JSON.
It opens a JS Array by a square bracket but does not close.   

```
[{...}
```
