### PR TITLE
add Tessel 2 as a directly connected device

### DIFF
--- a/Devices/DirectlyConnectedDevices/NodeJS/Tessel2/Hardware.md
+++ b/Devices/DirectlyConnectedDevices/NodeJS/Tessel2/Hardware.md
@@ -1,0 +1,11 @@
+# Hardware requirements for Tessel 2 and modules #
+
+ - [Tessel 2][1]
+
+## Supported Sensors ##
+
+- [Tessel 2 Ambient Module][2]
+
+
+  [1]: https://tessel.io/
+  [2]: https://tessel.io/modules#module-ambient

--- a/Devices/DirectlyConnectedDevices/NodeJS/Tessel2/Tessel2_setup.md
+++ b/Devices/DirectlyConnectedDevices/NodeJS/Tessel2/Tessel2_setup.md
@@ -1,0 +1,50 @@
+This document explains how to set up a Tessel 2 board to send data to Azure IoT services Hub using the AMQP interface.
+
+## Hardware requirements ##
+Check out the hardware requirements [here](hardware.md).
+
+## Prerequisites ##
+
+To deploy the application you will need the following:
+
+* Your preferred command line terminal
+* Wifi internet access for the Tessel 2 and your computer
+
+To work on the code of the project, you can use your favorite code editor.
+
+## Configure the Tessel 2 ##
+
+* Connect the Ambient module to Port A of the Tessel 2
+* Connect to the Tessel 2 via USB from your computer
+* Follow the instructions on the [Tessel 2 site](http://tessel.github.io/t2-start/) to install the t2 CLI tool, and connect the Tessel 2 to WiFi
+
+
+## Set up the app on the board ##
+
+* In your preferred terminal, type the following commands:
+
+                 mkdir t2_connect_the_dots
+                 cd t2_connect_the_dots
+                 wget https://github.com/Azure/connectthedots/raw/IoTHub/Devices/DirectlyConnectedDevices/NodeJS/Tessel2/tessel2ctd.js
+                 wget https://github.com/Azure/connectthedots/raw/IoTHub/Devices/DirectlyConnectedDevices/NodeJS/Tessel2/package.json
+                 wget https://github.com/Azure/connectthedots/raw/IoTHub/Devices/DirectlyConnectedDevices/NodeJS/Tessel2/settings.json
+                 npm install
+
+* Before running the app, you need to update the settings.json file to input the device's connection string and a unique device id.
+Following the instructions [here](../../../readme.md), to get the connection string for your device.
+
+* In your preferred code editor, open the file settings.json and edit the settings based on the configuration of your ehdevices Event Hub. Note that the device id shall be unique per device so that data is not messed up in the connectthedots portal.
+
+                 "iothubconnectionstring": "<connectionstring>",
+                 "deviceid": "<deviceid>",
+                 "displayname": "My Tessel 2",
+                 "organization": "My Org",
+                 "location":  "My location"
+
+* Once you have changed the settings file, you can test your app. To do this, you'll be using the t2 CLI to transfer your code over to the Tessel 2 while it's connected (you need to be in the /t2_connect_the_dots folder):
+
+        t2 run tessel2ctd.js
+
+* In order to run your app on the Tessel without tethering, use the `push` command instead:
+
+        t2 push tessel2ctd.js

--- a/Devices/DirectlyConnectedDevices/NodeJS/Tessel2/package.json
+++ b/Devices/DirectlyConnectedDevices/NodeJS/Tessel2/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "ConnectTheDotsTessel2",
+  "version": "1.0.0",
+  "description": "Simple Node app sending data from a Tessel 2 + Ambient Module to Azure IoT services",
+  "main": "tessel2ctd.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "ambient-attx4": "^0.2.11",
+    "connectthedots": "^1.0.3",
+    "tessel": "^0.3.25"
+  }
+}

--- a/Devices/DirectlyConnectedDevices/NodeJS/Tessel2/settings.json
+++ b/Devices/DirectlyConnectedDevices/NodeJS/Tessel2/settings.json
@@ -1,0 +1,7 @@
+﻿{
+    "iothubconnectionstring": "<connection-string>",
+    "deviceid": "<deviceid>",
+    "displayname": "My Tessel 2",
+    "organization": "My Org",
+    "location":  "My location"
+}

--- a/Devices/DirectlyConnectedDevices/NodeJS/Tessel2/tessel2ctd.js
+++ b/Devices/DirectlyConnectedDevices/NodeJS/Tessel2/tessel2ctd.js
@@ -1,0 +1,72 @@
+//  ---------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Open Technologies, Inc.  All rights reserved.
+// 
+//  The MIT License (MIT)
+// 
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+// 
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+// 
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//  ---------------------------------------------------------------------------------
+
+var connectthedots = require('connectthedots');
+var devicesettings = require('./settings.json');
+var tessel = require('tessel');
+var ambientlib = require('ambient-attx4');
+
+// main function to initialize the Tessel and start reading data
+var connect_the_dots = function () {
+  // Connect to our ambient sensor.
+  var ambient = ambientlib.use(tessel.port['A']);
+
+  console.log('Tessel 2 is ready to connect its dots');
+
+  // Read light and sound data at a 1 second interval
+  setInterval(function () {
+    // read some sound level data
+    ambient.getSoundLevel(function (err, sdata) {
+      if (err) throw err;
+      console.log('sound: ', sdata)
+      // read some light level data
+      ambient.getLightLevel(function (err, ldata) {
+        if (err) throw err;
+        console.log('light: ', ldata);
+
+        // send data to IoT Hub
+        connectthedots.send_message("Sound", "units", sdata);
+        connectthedots.send_message("Light", "units", ldata);
+      });
+    });
+  }, 1000);
+}
+
+var initCallback = function (err) {
+  // Once the connection to Azure IoT Hub is establish you can initialize your hardware and start sending data
+  // This is where you would insert your sensors code
+  connect_the_dots();
+};
+
+var receiveCallback = function (msg) {
+  // A message was received
+  console.log("Received Message. Message Id: " + msg.messageId + " ; Message data:" + msg.data.toString() );
+};
+
+
+// ---------------------------------------------------------------
+// Init app
+
+// Init connection to Azure IoT
+connectthedots.init_connection(devicesettings, initCallback, receiveCallback);


### PR DESCRIPTION
👋 Hallo!

I noticed that the [Tessel 2](https://tessel.io), a popular device for creating NodeJS based IoT projects was not a supported device. I have written setup instructions and a sample program to run. I decided to go with the Ambient sensor module, which provides both light and sound data.

I did a test deploy of the services to my Azure account. I am attaching a screen grab of it working as intended:

![2017-03-14 21_28_41-connect the dots](https://cloud.githubusercontent.com/assets/1411284/24114466/b6aca850-0d76-11e7-80bd-6c3ce467d25a.png)

It turned out to be a powerful project addition in the end, because of how quick it is to get a Tessel 2 up and running with this kind of approach.

Let me know what you think! I'm friendly with the Tessel Team (the 'Tesselators') so can cross promote if you think that'd be a positive outreach 😄 

Thanks for considering this pull request 🙇‍♀️ 


