### PR TITLE
Allow parsing of values sent through Webhooks

### DIFF
--- a/Azure/WebSite/source/ConnectTheDotsWebSite/WebSocketHandler.cs
+++ b/Azure/WebSite/source/ConnectTheDotsWebSite/WebSocketHandler.cs
@@ -197,7 +197,9 @@ namespace ConnectTheDotsWebSite
 			TimeSpan bufferTime = new TimeSpan(0, 10, 0);
 			DateTime now = DateTime.UtcNow;
 
-			if (message.ContainsKey("time"))
+            if (message.ContainsKey("unitofmeasure") && message.ContainsKey("value"))
+                message["value"] = float.Parse(message["value"].ToString());
+            if (message.ContainsKey("time"))
 				messageTime = DateTime.Parse(message["time"].ToString());
 			else if (message.ContainsKey("timestart"))
 				messageTime = DateTime.Parse(message["timestart"].ToString());


### PR DESCRIPTION
Webhook support will allow for usage of Particle devices with
ConnectTheDots through Particle's Iot-Hub integration:
https://docs.particle.io/tutorials/integrations/azure-iot-hub/

One current limitation of the Webhook format is that variables can only
be interpolated as strings. In particular this is not a valid template:
"json": { "value": {{PARTICLE_EVENT_VALUE}} }
https://docs.particle.io/reference/webhooks/#json

This breaks compatibility with the accepted format for value in the ConnectTheDots data format:

**Data format**

> ConnectTheDots is built on the assumption that data from sensors is sent to Azure IoT Hub in a prescribed JSON format. The minimum structure, with required attribute names, is
> {
>     "guid":	"string",
>     "organization":	"string",
>     "displayname": "string",
>     "location": "string",
>     "measurename": "string",
>     "unitofmeasure": "string",
>     "timecreated": "string",
>     "value": double/float/integer
> }