### PR TITLE
Address #257

### DIFF
--- a/Azure/WebSite/source/ConnectTheDotsWebSite/WebSocketEventProcessor.cs
+++ b/Azure/WebSite/source/ConnectTheDotsWebSite/WebSocketEventProcessor.cs
@@ -122,7 +122,15 @@ namespace ConnectTheDotsWebSite
 
                                 // Send alert to device
                                 var alertMessage = JsonConvert.SerializeObject(messagePayload).ToString();
-                                IoTHubHelper.SendMessage(messagePayload["guid"].ToString(), alertMessage);
+
+                                try
+                                {
+                                    IoTHubHelper.SendMessage(messagePayload["guid"].ToString(), alertMessage);
+                                }
+                                catch (Exception e)
+                                {
+                                    Trace.TraceError("Error notifying device {0}, check that message receiving is implemented on the device", messagePayload["guid"].ToString());
+                                }
 
                                 DateTime time = DateTime.Parse(messagePayload["timecreated"].ToString());
 								// find the nearest point


### PR DESCRIPTION
I am also noticing the same behavior described by @vntampasi in #257
when deploying from the ARM template:

![image](https://user-images.githubusercontent.com/2018336/27145683-457bcd04-50fc-11e7-918f-ded05167ecd3.png)

Able to workaround by adding try / catch around:
` IoTHubHelper.SendMessage(messagePayload["guid"].ToString(),
alertMessage);`
in WebSocketEventProcessor.cs

Attempting to message a device has not implemented a mechanism for
message receipt from the IoT Hub appears to be the reason for failure.