### PR TITLE
New preview API version broke template

### DIFF
--- a/Azure/ARMTemplate/azuredeploy.json
+++ b/Azure/ARMTemplate/azuredeploy.json
@@ -59,7 +59,7 @@
     "storageName": "[concat(parameters('solutionName'), 'storage')]",
     "storageId": "[resourceId('Microsoft.Storage/storageAccounts', variables('storageName'))]",
     "storageAccountSku": "Standard_LRS",
-    "sbVersion": "[providers('Microsoft.Eventhub', 'namespaces').apiVersions[0]]",
+    "sbVersion": "[providers('Microsoft.Eventhub', 'namespaces').apiVersions[1]]",
     "ehOutName": "ehalerts",
     "sbKeyName": "RootManageSharedAccessKey",
     "sbSku": 1,


### PR DESCRIPTION
There is a new preview API version for Event Hub that is not available for all resource types that is breaking this ARM template.
Azure PowerShell
((Get-AzureRmResourceProvider -ProviderNamespace Microsoft.eventhub).ResourceTypes | Where-Object ResourceTypeName -eq namespaces).ApiVersions
2018-01-01-preview
2017-04-01
2015-08-01
2014-09-01
((Get-AzureRmResourceProvider -ProviderNamespace Microsoft.eventhub).ResourceTypes | Where-Object Re
sourceTypeName -eq namespaces/authorizationrules).ApiVersions
2017-04-01
2015-08-01
2014-09-01

You can also hardcode the "2017-04-01" if you prefer, so if there is a new API available it won't break you template again.